### PR TITLE
Fix slashes in filenames.

### DIFF
--- a/obs_from_plano.php
+++ b/obs_from_plano.php
@@ -34,6 +34,7 @@ $index = <<<EOD
 EOD;
 
 foreach ($program->getLocations() as $fileName => $roomName) {
+    $fileName = str_replace('/', '_', $fileName);
     $program->writeObsRoomFile(PATH . "$fileName" . EXT, $roomName, $timeNow);
     $index .= '<li><a href="' . $fileName . EXT . '">' . $roomName . '</a></li>';
 }


### PR DESCRIPTION
If a room name contained slashes, the file name would look like a file path, and would cause an error about a missing subdirectory when writing the file. Replaces `/` with `_` in filename.